### PR TITLE
force release job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   release:
     environment: release
+    name: release
     uses: ssbarnea/gha-playground/.github/workflows/check.yml@main
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
this should avoid ugly job name when using 'uses:'